### PR TITLE
Reserve missions

### DIFF
--- a/src/components/MissionsTable.css
+++ b/src/components/MissionsTable.css
@@ -30,7 +30,7 @@
 }
 
 .joinMission {
-  background:none;
+  background: none;
   border: 1px solid #6d757d;
   font-size: 1rem;
   padding: 8px;

--- a/src/components/MissionsTable.css
+++ b/src/components/MissionsTable.css
@@ -30,9 +30,19 @@
 }
 
 .joinMission {
-  background-color: #fff;
-  border: 1px solid #ddd;
+  background:none;
+  border: 1px solid #6d757d;
+  font-size: 1rem;
   padding: 8px;
   margin-left: 30%;
   cursor: pointer;
+  border-radius: 7px;
+  color: #6d757d;
+}
+
+.status {
+  text-align: center;
+  color: #fff;
+  padding: 3px;
+  border-radius: 7px;
 }

--- a/src/components/MissionsTable.css
+++ b/src/components/MissionsTable.css
@@ -1,7 +1,7 @@
 /* MissionsList.css */
 
 .missions-table {
-  width: 95%;
+  width: 80%;
   border-collapse: collapse;
   margin: 20px auto;
   padding: 10px;
@@ -26,7 +26,11 @@
 }
 
 .wider-column {
-  width: 40%;
+  width: 60%;
+}
+
+.missionColumn {
+  width: 10%;
 }
 
 .joinMission {

--- a/src/components/MissionsTableComponent.jsx
+++ b/src/components/MissionsTableComponent.jsx
@@ -20,7 +20,7 @@ function MissionsTableComponent() {
     <table className="missions-table">
       <thead>
         <tr>
-          <th>Mission</th>
+          <th className="missionColumn">Mission</th>
           <th className="wider-column">Description</th>
           <th>Status</th>
           <th />

--- a/src/components/MissionsTableComponent.jsx
+++ b/src/components/MissionsTableComponent.jsx
@@ -1,11 +1,20 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
 import React from 'react';
-import { useSelector } from 'react-redux';
-import { selectMappedMissions } from '../redux/missions/missionsSlice';
+import { useDispatch, useSelector } from 'react-redux';
+import { joinMission, leaveMission, selectMappedMissions } from '../redux/missions/missionsSlice';
 import './MissionsTable.css';
 
 function MissionsTableComponent() {
+  const dispatch = useDispatch();
   const mappedMissions = useSelector(selectMappedMissions);
+
+  const handleToggleMission = (missionId, reserved) => {
+    if (reserved) {
+      dispatch(leaveMission(missionId));
+    } else {
+      dispatch(joinMission(missionId));
+    }
+  };
 
   return (
     <table className="missions-table">
@@ -19,11 +28,23 @@ function MissionsTableComponent() {
       </thead>
       <tbody>
         {mappedMissions.map((mission, index) => (
-          <tr key={mission.mission_id} className={index % 2 === 0 ? 'even-row' : 'odd-row'}>
+          <tr
+            key={mission.mission_id}
+            className={index % 2 === 0 ? 'even-row' : 'odd-row'}
+          >
             <td className="bold-text">{mission.mission_name}</td>
             <td>{mission.description}</td>
-            <td>{mission.status === 'a member' ? 'A Member' : 'Not a Member'}</td>
-            <td className="joinContainer"><button type="button" className="joinMission">Join Mission</button></td>
+            <td><p style={{ backgroundColor: mission.reserved ? '#419bf9' : '#6d757d' }} className="status">{mission.reserved ? 'ACTIVE MEMBER' : 'NOT A MEMBER'}</p></td>
+            <td className="joinContainer">
+              <button
+                type="button"
+                className="joinMission"
+                onClick={() => handleToggleMission(mission.mission_id, mission.reserved)}
+                style={{ color: mission.reserved ? 'red' : '', border: mission.reserved ? '1px solid red' : '' }}
+              >
+                {mission.reserved ? 'Leave Mission' : 'Join Mission'}
+              </button>
+            </td>
           </tr>
         ))}
       </tbody>

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -1,8 +1,8 @@
+/* eslint-disable max-len */
 // missionsSlice.js
 
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { createSelector } from 'reselect';
 
 const missionsUrl = 'https://api.spacexdata.com/v3/missions';
@@ -24,7 +24,16 @@ const missionsSlice = createSlice({
     status: 'idle',
     error: null,
   },
-  reducers: {},
+  reducers: {
+    joinMission: (state, action) => {
+      const missionId = action.payload;
+      state.data = state.data.map((mission) => (mission.mission_id === missionId ? { ...mission, reserved: true } : mission));
+    },
+    leaveMission: (state, action) => {
+      const missionId = action.payload;
+      state.data = state.data.map((mission) => (mission.mission_id === missionId ? { ...mission, reserved: false } : mission));
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(getMissions.pending, (state) => {
@@ -51,7 +60,10 @@ export const selectMappedMissions = createSelector(
     mission_id: mission.mission_id,
     mission_name: mission.mission_name,
     description: mission.description,
+    reserved: mission.reserved || false, // Default reserved status
   })),
 );
+
+export const { joinMission, leaveMission } = missionsSlice.actions;
 
 export default missionsSlice.reducer;

--- a/src/redux/rocketSlice.js
+++ b/src/redux/rocketSlice.js
@@ -13,7 +13,6 @@ export const fetchRocketsAsync = createAsyncThunk(
   'rockets/fetchRockets',
   async () => {
     const response = await axios.get(baseUrl);
-    console.log(response.data);
     return response.data;
   },
 );


### PR DESCRIPTION
### 🛰️ **Feature: Mission Participation Status and Conditional Rendering**

This pull request introduces an enhanced user experience by implementing mission participation status updates and conditional rendering. When a user interacts with the "Join Mission" and "Leave Mission" buttons, actions are dispatched to update the store's mission data. The state is managed in an immutable manner, creating new state objects with the selected mission's participation status updated. The UI adapts to display the corresponding participation status and buttons, enhancing user interaction.

**Changes Made:**

- Implemented logic to update mission participation status upon clicking "Join Mission" and "Leave Mission" buttons.
- Utilized `map()` to create new state objects with updated mission participation status.
- Dispatched actions upon button clicks to trigger state updates.
- Implemented conditional rendering syntax to display participation status badges and buttons based on the user's membership status.

**Conditional Rendering:**

- If a user joins a mission, the mission's **"Active Member"** badge is displayed, and the button changes to "Leave Mission".
- If a user leaves a mission, the default **"NOT A MEMBER"** badge is displayed, and the button changes back to "Join Mission".

**Note:**

> Mission data in the state is updated immutably to maintain data integrity.
> The conditional rendering syntax simplifies the dynamic display of UI elements based on user actions.

By incorporating mission participation status updates and implementing conditional rendering based on user actions, this PR enhances the application's usability, making it more intuitive and interactive.

🚀 Please review and merge to bring the improved mission participation features to the application!
